### PR TITLE
Deleted duplicated compile dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,4 @@ dependencies {
   compile 'com.google.code.gson:gson:2.7'
 
   compile 'org.jetbrains:annotations:15.0'
-  compile 'org.jetbrains:annotations:15.0'
-  compile 'org.jetbrains:annotations:15.0'
-  compile 'org.jetbrains:annotations:15.0'
 }


### PR DESCRIPTION
Root build.gradle contains duplicated compile dependencies for 'org.jetbrains:annotations:15.0'.
