### PR TITLE
Make newline platform-independent

### DIFF
--- a/src/main/java/tiger/NewDependencyCollector.java
+++ b/src/main/java/tiger/NewDependencyCollector.java
@@ -378,7 +378,7 @@ class NewDependencyCollector {
           || newInfo.getType().equals(Provides.Type.UNIQUE)) {
         String error =
             String.format(
-                "Adding dependencies failed.\n %s\nAlready existing: %s", newInfo, dependencyInfoSet);
+                "Adding dependencies failed.%n %s%nAlready existing: %s", newInfo, dependencyInfoSet);
         errors.add(error);
       }
     }

--- a/src/main/java/tiger/NewScopeCalculator.java
+++ b/src/main/java/tiger/NewScopeCalculator.java
@@ -130,7 +130,7 @@ class NewScopeCalculator {
     if (!allScopes.keySet().containsAll(bindingsRequired)) {
       errors.add(
           String.format(
-              "Scope of required keys not calculated.\nDiff: %s\nRequired: %s\nCalculated: %s",
+              "Scope of required keys not calculated.%nDiff: %s%nRequired: %s%nCalculated: %s",
               Sets.difference(bindingsRequired, allScopes.keySet()),
               bindingsRequired,
               allScopes));


### PR DESCRIPTION
When you [format strings](http://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax), using the `%n` specifier will produce the platform-specific line separator.
